### PR TITLE
fix(template): Iteritems doesn't work with current Ansible versions

### DIFF
--- a/templates/etc/ipsec.conf.j2
+++ b/templates/etc/ipsec.conf.j2
@@ -2,18 +2,18 @@
 # {{strongswan_config_file}} - strongSwan IPsec configuration file
 
 config setup
-{% for k,v in strongswan_config_setup.iteritems() %}
+{% for k,v in strongswan_config_setup.items() %}
 	{{k}}={{v}}
 {% endfor %}
 
 conn %default
-{% for k,v in strongswan_conn_default.iteritems() %}
+{% for k,v in strongswan_conn_default.items() %}
 	{{k}}={{v}}
 {% endfor %}
 
-{% for conn,conn_settings in strongswan_conns.iteritems() %}
+{% for conn,conn_settings in strongswan_conns.items() %}
 conn {{conn}}
-{%   for k,v in conn_settings.iteritems() %}
+{%   for k,v in conn_settings.items() %}
 	{{k}}={{v}}
 {%   endfor %}
 


### PR DESCRIPTION
The method `iteritems` doesn't exists in Python 3, so it's not working with ansible using the current interpreter.
For those who choose to use the deprecated Python version, `items()` is working, avoiding retrocompatibility issues