### PR TITLE
fix ansible deprecation warnings on handlers

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,12 +3,12 @@
 - name: ipsec reload
   command: >
     {{strongswan_ipsec_bin}} reload
-  when: not (_strongswan_pkgs|changed)
+  when: _strongswan_pkgs is not changed
 
 - name: ipsec secrets reload
   command: >
     {{strongswan_ipsec_bin}} rereadsecrets
-  when: not (_strongswan_pkgs|changed)
+  when: _strongswan_pkgs is not changed
 
 
 # vi:ts=2:sw=2:et:ft=yaml


### PR DESCRIPTION
This commit fixes the following deprecation warning:

```
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|changed` use
`result is changed`. This feature will be removed in version 2.9. Deprecation warnings can be disabled
 by setting deprecation_warnings=False in ansible.cfg.
```