### PR TITLE
hide secrets from diff output

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -16,6 +16,7 @@
     owner: "root"
     group: "root"
     mode: "0640"
+  diff: no
   notify: ipsec secrets reload
 
 # vi:ts=2:sw=2:et:ft=yaml


### PR DESCRIPTION
* This patch hides any changes to the ipsec.secrets file from showing in the ansible log even with `--diff` param specified.

Requires ansible v2.4+