### PR TITLE
Ubuntu installation and multiple improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,15 @@ An Ansible Role that installs and configures StrongSwan on Red Hat/CentOS or Deb
 ## Tested On
 
   * EL / Centos (7 / 6)
-  * Ubuntu (Xenial / Trusty / Precise)
+  * Ubuntu (Focal / Xenial / Trusty / Precise)
+
+
+### Debian Strongswan Versions
+When installing Strongswan on the Debian-based distros, a `strongswan_version` var may be used. 
+
+Available versions: https://download.strongswan.org/.
+> **5.8.2** used as default in this role. 
+
 
 
 ## Role Variables
@@ -25,9 +33,9 @@ The `ipsec.conf` file is configured through the following vars (and their defaul
 
 ```
 strongswan_config_setup:
-  uniqueids: yes
-  charonstart: yes
-  charondebug: ''
+  charondebug: 'dmn 2, mgr 2, ike 2, chd 2, job 2, cfg 2, knl 2, net 2, enc 2 lib 2'
+  uniqueids: 'yes'
+  strictcrlpolicy: 'no'
 
 strongswan_conn_default: {}
 
@@ -42,6 +50,26 @@ element might contain the following attributes:
   type:       Optional (defaults to PSK) - any valid secret type
   credential: Required - Connection's credentials
 ```
+
+An updown script can be used to specify interface parameters of the VTI interface:
+```
+   strongswan_updown:
+     out_int: 'eth0'                # public interface
+     vti_int: 'vti100'              # Virtual Tunnel Interface
+     vti_local: '192.168.0.5/31'    # leftsourceip/mask
+     vti_nexthop: '192.168.0.4'     # rightsourceip
+```
+Script path is `{{ strongswan_prefix }}`/strongswan/updown.sh. Should be referenced under `strongswan_conns`:
+> leftupdown=/etc/strongswan/updown.sh
+
+Disabled by default.
+
+
+#### Logging
+Default logfile is */var/log/charon.log*.
+
+Can be changed by overwriting `charon_filelog` value. 
+
 
 ## Usage
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,13 +1,13 @@
 ---
-
+strongswan_version: "5.8.2"
 strongswan_config_file:  "{{strongswan_prefix}}/ipsec.conf"
-
 strongswan_secrets_file: "{{strongswan_prefix}}/ipsec.secrets"
+charon_filelog: "/var/log/charon.log"
 
 strongswan_config_setup:
+  charondebug: 'dmn 2, mgr 2, ike 2, chd 2, job 2, cfg 2, knl 2, net 2, enc 2 lib 2'
   uniqueids: 'yes'
-  charonstart: 'yes'
-  charondebug: ''
+  strictcrlpolicy: 'no'
 
 # strongswan_conn_default: Defaults for connections
 #  This will populate the default conn (%default)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,7 +32,7 @@ strongswan_conn_default: {}
 #       ike: aes256-sha1-modp1024
 #       esp: aes256-sha1-modp1024
 #       auto: start
-#
+#       leftupdown=/etc/strongswan/updown.sh
 strongswan_conns: {}
 
 # strongswan_secrets: List of secrets to define
@@ -55,9 +55,9 @@ strongswan_secrets: []
 # Disabled by default.
 #
 #   strongswan_updown:
-#     out_int: 'eth0'              # leftid
+#     out_int: 'eth0'              # public interface
 #     vti_int: 'vti100'            # Virtual Tunnel Interface
-#     vti_local: '192.168.0.5/31'  # leftsourceip
+#     vti_local: '192.168.0.5/31'  # leftsourceip/mask
 #     vti_nexthop: '192.168.0.4'   # rightsourceip
 
 strongswan_updown: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,4 +51,15 @@ strongswan_conns: {}
 
 strongswan_secrets: []
 
+# strongswan_updown: Dict to specify interface parameters for updown script.
+# Disabled by default.
+#
+#   strongswan_updown:
+#     out_int: 'eth0'              # leftid
+#     vti_int: 'vti100'            # Virtual Tunnel Interface
+#     vti_local: '192.168.0.5/31'  # leftsourceip
+#     vti_nexthop: '192.168.0.4'   # rightsourceip
+
+strongswan_updown: {}
+
 # vi:ts=2:sw=2:et:ft=yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 strongswan_version: "5.8.2"
 strongswan_config_file:  "{{strongswan_prefix}}/ipsec.conf"
 strongswan_secrets_file: "{{strongswan_prefix}}/ipsec.secrets"
+strongswan_configure_extra_args: "--enable-systemd --enable-swanctl"
 charon_filelog: "/var/log/charon.log"
 
 strongswan_config_setup:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,8 @@
 ---
 
-- name: ipsec reload
+- name: ipsec restart
   command: >
-    {{strongswan_ipsec_bin}} reload
+    {{strongswan_ipsec_bin}} restart
 
 - name: ipsec secrets reload
   command: >

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,12 +3,9 @@
 - name: ipsec reload
   command: >
     {{strongswan_ipsec_bin}} reload
-  when: not (_strongswan_pkgs|changed)
 
 - name: ipsec secrets reload
   command: >
     {{strongswan_ipsec_bin}} rereadsecrets
-  when: not (_strongswan_pkgs|changed)
-
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
         - precise
         - trusty
         - xenial
+        - focal
 
   galaxy_tags:
     - system

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -18,4 +18,24 @@
     mode: "0640"
   notify: ipsec secrets reload
 
+- name: Strongswan updown script
+  block:
+    - name: create strongswan directory
+      file:
+        path: "{{strongswan_prefix}}/strongswan"
+        state: directory
+        recurse: yes
+        owner: "root"
+        group: "root"
+
+    - name: add updown script
+      template:
+        src: strongswan/updown.sh.j2
+        dest: "{{ strongswan_prefix }}/strongswan/updown.sh"
+        owner: "root"
+        group: "root"
+        mode: "0755"
+  when: strongswan_updown
+
+
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -35,7 +35,7 @@
         owner: "root"
         group: "root"
         mode: "0755"
-  when: strongswan_updown
+  when: strongswan_updown is defined and strongswan_updown.keys()|length > 0
 
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,5 +1,19 @@
 ---
 
+- name: sysctl tweaks
+  sysctl:
+    name: '{{ item.name }}'
+    value: '{{ item.value }}'
+    sysctl_set: true
+    state: present
+    reload: true
+  loop:
+    - {name: 'net.ipv4.ip_forward', value: '1'}
+    - {name: 'net.ipv4.conf.all.rp_filter', value: '0'}
+    - {name: 'net.ipv4.conf.default.rp_filter', value: '0'}
+    - {name: 'net.ipv4.conf.all.send_redirects', value: '0'}
+    - {name: 'net.ipv4.conf.default.send_redirects', value: '0'}
+
 - name: Strongswan ipsec.conf
   template:
     src: etc/ipsec.conf.j2
@@ -7,7 +21,7 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  notify: ipsec reload
+  notify: ipsec restart
 
 - name: Strongswan ipsec.secrets
   template:
@@ -35,7 +49,20 @@
         owner: "root"
         group: "root"
         mode: "0755"
+      notify: ipsec restart
   when: strongswan_updown is defined and strongswan_updown.keys()|length > 0
 
+- name: setup logfile
+  template:
+    src: strongswan/charon-logging.conf.j2
+    dest: /etc/strongswan.d/charon-logging.conf
+  notify: ipsec restart
+
+- name: disable routes installing by charon
+  replace:
+    path: /etc/strongswan.d/charon.conf
+    regexp: '^.*install_routes.*yes|^.*#.*install_routes.*'
+    replace: 'install_routes = no'
+  notify: ipsec restart
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,11 +2,4 @@
 
 - include: "install/{{ansible_os_family}}.yml"
 
-- name: Strongswan packages
-  package:
-    name: "{{item}}"
-    state: present
-  with_items: "{{strongswan_packages}}"
-  register: _strongswan_pkgs
-
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -1,3 +1,41 @@
 ---
 
+- name: check if ipsec cmd exists
+  command: which ipsec
+  changed_when: false
+  failed_when: false
+  register: strongswan_installed
+
+- name: installation
+  block:
+  - name: prerequisite packages
+    apt:
+      name: [gcc, libgmp3-dev, make]
+      state: present
+      update_cache: yes
+
+  - name: get strongswan tarball
+    unarchive:
+      src: 'https://download.strongswan.org/strongswan-{{ strongswan_version }}.tar.bz2'
+      dest: /tmp
+      remote_src: yes
+
+  - name: run configure script
+    command: ./configure --prefix=/usr --sysconfdir=/etc
+    args:
+      chdir: '/tmp/strongswan-{{ strongswan_version }}'
+    become: true
+
+  - name: build default target
+    make:
+      chdir: '/tmp/strongswan-{{ strongswan_version }}'
+
+  - name: run 'install' target
+    make:
+      chdir: '/tmp/strongswan-{{ strongswan_version }}'
+      target: install
+    become: true
+    notify: ipsec restart
+  when: strongswan_installed.rc != 0
+
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -21,7 +21,9 @@
       remote_src: yes
 
   - name: run configure script
-    command: ./configure --prefix=/usr --sysconfdir=/etc
+    command: >
+      ./configure --prefix=/usr --sysconfdir=/etc
+      {{ strongswan_configure_extra_args }}
     args:
       chdir: '/tmp/strongswan-{{ strongswan_version }}'
     become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,4 @@
 - include: config.yml
   tags: strongswan_config
 
-- include: service.yml
-  tags: strongswan_service
-
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,9 +1,0 @@
----
-
-- name: Enable Strongswan at boot
-  service:
-    name: strongswan
-    enabled: true
-    state: started
-
-# vi:ts=2:sw=2:et:ft=yaml

--- a/templates/etc/ipsec.conf.j2
+++ b/templates/etc/ipsec.conf.j2
@@ -1,20 +1,22 @@
-# << Ansible managed file >>
+{{ ansible_managed | comment }}
 # {{strongswan_config_file}} - strongSwan IPsec configuration file
 
 config setup
-{% for k,v in strongswan_config_setup.items() %}
-	{{k}}={{v}}
-{% endfor %}
+  charondebug="{{ strongswan_config_setup.charondebug }}"
+  uniqueids={{ strongswan_config_setup.uniqueids }}
+  strictcrlpolicy={{ strongswan_config_setup.strictcrlpolicy }}
 
+{% if strongswan_conn_default is defined and strongswan_conn_default != {} %}
 conn %default
-{% for k,v in strongswan_conn_default.items() %}
-	{{k}}={{v}}
-{% endfor %}
+{%   for k,v in strongswan_conn_default.items() %}
+  {{k}}={{v}}
+{%   endfor %}
+{% endif %}
 
 {% for conn,conn_settings in strongswan_conns.items() %}
 conn {{conn}}
-{%   for k,v in conn_settings.items() %}
-	{{k}}={{v}}
+{%   for k,v in conn_settings.items()|sort(attribute='0') %}
+  {{k}}={{v}}
 {%   endfor %}
 
 {% endfor %}

--- a/templates/etc/ipsec.secrets.j2
+++ b/templates/etc/ipsec.secrets.j2
@@ -1,4 +1,4 @@
-# << Ansible managed file >>
+{{ ansible_managed | comment }}
 # {{strongswan_secrets_file}} - strongSwan IPsec secrets file
 
 {% for s in strongswan_secrets %}

--- a/templates/strongswan/charon-logging.conf.j2
+++ b/templates/strongswan/charon-logging.conf.j2
@@ -1,0 +1,18 @@
+{{ ansible_managed | comment }}
+charon {
+    filelog {
+        charon_log {
+            append = no
+            default = 2
+            flush_line = yes
+            ike_name = yes
+            path = {{ charon_filelog }}
+            time_add_ms = yes
+            time_format = %b %e %T
+        }
+    }
+
+    syslog {
+    }
+}
+

--- a/templates/strongswan/updown.sh.j2
+++ b/templates/strongswan/updown.sh.j2
@@ -24,7 +24,8 @@ case "${PLUTO_VERB}" in
         $IP addr add ${VTI_LOCAL} remote ${VTI_REMOTE} dev "${VTI_IF}"
         $IP link set ${VTI_IF} up mtu 1436
         sysctl -w net.ipv4.conf.${VTI_IF}.disable_policy=1
-        sysctl -w net.ipv4.conf.${VTI_IF}.rp_filter=2 || sysctl -w net.ipv4.conf.${VTI_IF}.rp_filter=0
+        sysctl -w net.ipv4.conf.${VTI_IF}.rp_filter=0
+        sysctl -w net.ipv4.conf.${VTI_IF}.send_redirects=0
         $IPTABLES -t mangle -I FORWARD -o ${VTI_IF} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
         $IPTABLES -t mangle -I INPUT -p esp -s ${PLUTO_PEER} -d ${PLUTO_ME} -j MARK --set-xmark ${PLUTO_MARK_IN}
         $IP route add 10.0.0.0/8 via $VTI_NEXTHOP
@@ -47,3 +48,5 @@ esac
 sysctl -w net.ipv4.ip_forward=1
 sysctl -w net.ipv4.conf.$INT.disable_xfrm=1
 sysctl -w net.ipv4.conf.$INT.disable_policy=1
+sysctl -w net.ipv4.conf.$INT.send_redirects=0
+sysctl -w net.ipv4.conf.$INT.rp_filter=0

--- a/templates/strongswan/updown.sh.j2
+++ b/templates/strongswan/updown.sh.j2
@@ -1,5 +1,3 @@
-{{ ansible_managed | comment }}
-
 #!/bin/bash
 
 set -o nounset

--- a/templates/strongswan/updown.sh.j2
+++ b/templates/strongswan/updown.sh.j2
@@ -13,8 +13,8 @@ PLUTO_MARK_IN_ARR=(${PLUTO_MARK_IN//// })
 
 INT={{ strongswan_updown.out_int }}
 VTI_IF="{{ strongswan_updown.vti_int }}"
-VTI_NEXTHOP="{{ strongswan_updown.vti_local }}"
-VTI_LOCAL="{{ strongswan_updown.vti_nexthop }}"
+VTI_NEXTHOP="{{ strongswan_updown.vti_nexthop }}"
+VTI_LOCAL="{{ strongswan_updown.vti_local }}"
 VTI_REMOTE="$VTI_NEXTHOP/31"
 
 

--- a/templates/strongswan/updown.sh.j2
+++ b/templates/strongswan/updown.sh.j2
@@ -1,0 +1,49 @@
+{{ ansible_managed | comment }}
+
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+
+IP=$(which ip)
+IPTABLES=$(which iptables)
+PLUTO_MARK_OUT_ARR=(${PLUTO_MARK_OUT//// })
+PLUTO_MARK_IN_ARR=(${PLUTO_MARK_IN//// })
+
+
+INT={{ strongswan_updown.out_int }}
+VTI_IF="{{ strongswan_updown.vti_int }}"
+VTI_NEXTHOP="{{ strongswan_updown.vti_local }}"
+VTI_LOCAL="{{ strongswan_updown.vti_nexthop }}"
+VTI_REMOTE="$VTI_NEXTHOP/31"
+
+
+case "${PLUTO_VERB}" in
+    up-client)
+        $IP link add ${VTI_IF} type vti local ${PLUTO_ME} remote ${PLUTO_PEER} okey ${PLUTO_MARK_OUT_ARR[0]} ikey ${PLUTO_MARK_IN_ARR[0]}
+        $IP addr add ${VTI_LOCAL} remote ${VTI_REMOTE} dev "${VTI_IF}"
+        $IP link set ${VTI_IF} up mtu 1436
+        sysctl -w net.ipv4.conf.${VTI_IF}.disable_policy=1
+        sysctl -w net.ipv4.conf.${VTI_IF}.rp_filter=2 || sysctl -w net.ipv4.conf.${VTI_IF}.rp_filter=0
+        $IPTABLES -t mangle -I FORWARD -o ${VTI_IF} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+        $IPTABLES -t mangle -I INPUT -p esp -s ${PLUTO_PEER} -d ${PLUTO_ME} -j MARK --set-xmark ${PLUTO_MARK_IN}
+        $IP route add 10.0.0.0/8 via $VTI_NEXTHOP
+        $IP route add 172.18.0.0/15 via $VTI_NEXTHOP
+        $IP route add 192.168.0.0/16 via $VTI_NEXTHOP
+        $IP route flush table 220
+        ;;
+    down-client)
+        $IP tunnel del "${VTI_IF}"
+        $IPTABLES -t mangle -D FORWARD -o ${VTI_IF} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+        $IPTABLES -t mangle -D INPUT -p esp -s ${PLUTO_PEER} -d ${PLUTO_ME} -j MARK --set-xmark ${PLUTO_MARK_IN}
+        $IP route del 10.0.0.0/8 via $VTI_NEXTHOP
+        $IP route del 172.18.0.0/15 via $VTI_NEXTHOP
+        $IP route del 192.168.0.0/16 via $VTI_NEXTHOP
+        ;;
+esac
+
+
+# Enable IPv4 forwarding
+sysctl -w net.ipv4.ip_forward=1
+sysctl -w net.ipv4.conf.$INT.disable_xfrm=1
+sysctl -w net.ipv4.conf.$INT.disable_policy=1

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,8 +1,5 @@
 ---
 
-strongswan_packages:
-  - strongswan
-
 strongswan_prefix: /etc
 
 strongswan_ipsec_bin: /usr/sbin/ipsec


### PR DESCRIPTION
- Enables choosing version of strongswan by building from source rather than installing with `apt`  (Debian only)
- Tweaks sysctl to disable RPF and redirects; also enables forwarding
- Adds updown script for tunnel establishment (disabled by default, but may be used according to README)
- Enables separate logfile instead of using syslog
- Disables adding `strongswan_conns` parameters if vars are undefined
- `strongswan_config_setup` is a dict now - `charondebug` parameter needs to be enclosed in quotes unlike others in this section


Every change is documented in README and `defaults/main.yml` with usage examples.