### PR TITLE
changing filter to python style

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,12 +3,12 @@
 - name: ipsec reload
   command: >
     {{strongswan_ipsec_bin}} reload
-  when: not (_strongswan_pkgs|changed)
+  when: not (_strongswan_pkgs is changed)
 
 - name: ipsec secrets reload
   command: >
     {{strongswan_ipsec_bin}} rereadsecrets
-  when: not (_strongswan_pkgs|changed)
+  when: not (_strongswan_pkgs is changed)
 
 
 # vi:ts=2:sw=2:et:ft=yaml


### PR DESCRIPTION
ansible 2.10.15:

FAILED! => {"msg": "The conditional check 'not (_strongswan_pkgs|changed)' failed. The error was: No filter named 'changed' found.
